### PR TITLE
feat(setting) blue spell learn chance

### DIFF
--- a/conf/default/map.conf
+++ b/conf/default/map.conf
@@ -224,3 +224,8 @@ msg_server_ip: connect
 #anticheat_enabled: 1
 #Set to 1 to completely disable auto-jailing offenders
 #anticheat_jail_disable: 0
+
+###METAL SETTINGS###
+
+#Increases chance to learn Blue Mage spells. Retail is 33% chance, set to >= 77 to garauntee spells are learned.
+blue_spell_learn_chance: 77

--- a/conf/default/map.conf
+++ b/conf/default/map.conf
@@ -228,4 +228,4 @@ msg_server_ip: connect
 ###METAL SETTINGS###
 
 #Increases chance to learn Blue Mage spells. Retail is 33% chance, set to >= 77 to garauntee spells are learned.
-blue_spell_learn_chance: 77
+blue_spell_learn_chance: 17

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1372,6 +1372,10 @@ int32 map_config_read(const int8* cfgName)
         {
             map_config.anticheat_jail_disable = atoi(w2);
         }
+        else if (strcmp(w1, "blue_spell_learn_chance") == 0)
+        {
+            map_config.blue_spell_learn_chance = atoi(w2);
+        }
         else
         {
             ShowWarning(CL_YELLOW"Unknown setting '%s' in file %s\n" CL_RESET, w1, cfgName);

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -139,6 +139,7 @@ struct map_config_t
     bool   skillup_bloodpact;         // Enable/disable skillups for bloodpacts
     bool   anticheat_enabled;         // Is the anti-cheating system enabled
     bool   anticheat_jail_disable;    // Globally disable auto-jailing by the anti-cheat system
+    int16  blue_spell_learn_chance;   // Increase chance to learn blue spells.
 };
 
 /************************************************************************

--- a/src/map/utils/blueutils.cpp
+++ b/src/map/utils/blueutils.cpp
@@ -134,7 +134,7 @@ void TryLearningSpells(CCharEntity* PChar, CMobEntity* PMob) {
             // make sure the difference between spell skill and player is at most 31 points
             if (playerSkillLvl >= skillLvlForSpell - 31)
             {
-                auto chanceToLearn = 33 + PBlueMage->getMod(Mod::BLUE_LEARN_CHANCE);
+                auto chanceToLearn = 33 + PBlueMage->getMod(Mod::BLUE_LEARN_CHANCE) + map_config.blue_spell_learn_chance;
                 if (tpzrand::GetRandomNumber(100) < chanceToLearn) {
 					if (charutils::addSpell(PBlueMage, static_cast<uint16>(PSpell->getID()))) {
 						PBlueMage->pushPacket(new CMessageBasicPacket(PBlueMage, PBlueMage, static_cast<uint16>(PSpell->getID()), 0, MSGBASIC_LEARNS_SPELL));

--- a/src/map/utils/blueutils.cpp
+++ b/src/map/utils/blueutils.cpp
@@ -26,6 +26,8 @@
 
 #include <math.h>
 
+#include "../map.h"
+
 #include "../packets/message_basic.h"
 #include "../packets/char_stats.h"
 #include "../packets/char_health.h"


### PR DESCRIPTION
Adds a settings to customize Blue Mage spell learning chance.  Retail is 33%, making this >=77 would guarantee the spell is learned.

